### PR TITLE
fix: Remove --all-features from CI to prevent assembly linking conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo fmt --all -- --check
         
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -W clippy::style -W clippy::complexity -W clippy::perf
+        run: cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious -W clippy::style -W clippy::complexity -W clippy::perf
 
   # Security and dependency checks
   security:
@@ -92,10 +92,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           
       - name: Run tests
-        run: cargo test --all-features --verbose
-        
+        run: cargo test --verbose
+
       - name: Run doc tests
-        run: cargo test --doc --all-features
+        run: cargo test --doc
 
   # Documentation generation
   docs:
@@ -117,11 +117,11 @@ jobs:
           key: ${{ runner.os }}-docs-cargo-${{ hashFiles('**/Cargo.lock') }}
           
       - name: Generate documentation
-        run: cargo doc --all-features --no-deps
-        
+        run: cargo doc --no-deps
+
       - name: Check for broken links in docs
         run: |
-          cargo doc --all-features --no-deps 2>&1 | tee doc_output.log
+          cargo doc --no-deps 2>&1 | tee doc_output.log
           ! grep -i "warning.*broken.*link" doc_output.log
 
   # Benchmark regression testing
@@ -144,7 +144,7 @@ jobs:
           key: ${{ runner.os }}-bench-cargo-${{ hashFiles('**/Cargo.lock') }}
           
       - name: Run benchmarks
-        run: cargo bench --all-features
+        run: cargo bench
 
   # Cross-compilation testing
   cross-compile:
@@ -175,7 +175,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           
       - name: Cross compile
-        run: cargo check --target ${{ matrix.target }} --all-features
+        run: cargo check --target ${{ matrix.target }}
 
   # Minimum Supported Rust Version (MSRV) check
   msrv:
@@ -199,4 +199,4 @@ jobs:
           key: ${{ runner.os }}-msrv-cargo-${{ hashFiles('**/Cargo.lock') }}
           
       - name: Check MSRV compatibility
-        run: cargo check --all-features
+        run: cargo check


### PR DESCRIPTION
- Remove --all-features flag from all CI commands (test, clippy, doc, bench, cross-compile, MSRV)
- Prevents simultaneous enabling of conflicting assembly features (x86_64, aarch64, apple_silicon, no_assembly)
- Fixes 'undefined symbol' linking errors on nightly toolchain in Linux CI
- Uses default features (auto_assembly) which automatically selects correct assembly for platform
- Resolves assembly linking failures: apple_hybrid_clean_char_optimized, hybrid_clean_char_x86_64, hybrid_clean_char_aarch64

The --all-features flag was causing the build to try to link assembly functions from all platforms simultaneously, which don't exist on the target platform (e.g., Apple Silicon assembly on Linux x86_64). Using default features allows auto_assembly to select the appropriate assembly for each platform.